### PR TITLE
TS-13 fix unsigned compare for warning escalation

### DIFF
--- a/TextSearch/Common/NumericCollationFormat.ecl
+++ b/TextSearch/Common/NumericCollationFormat.ecl
@@ -39,7 +39,7 @@ EXPORT NumericCollationFormat := MODULE
     int expnt = 0;
     char ch = '\0';
 
-    for (int i = 0; i < lenNumstr; i++)
+    for (int i = 0; i < (int)lenNumstr; i++)
     {
       if ((ch = numstr[i]) == '.')
       {

--- a/TextSearch/Resolved/Dict_Lookup.ecl
+++ b/TextSearch/Resolved/Dict_Lookup.ecl
@@ -36,7 +36,7 @@ Dict_Lookup(InfoBlock info, TermType typ, TermString term, KWMod kwm) := FUNCTIO
   BOOLEAN containsWildCardChar(UNICODE str) := BEGINC++
   #option pure
     bool answer = false;
-    for(int i=0; i < lenStr && !answer; i++) {
+    for(int i=0; i < (int)lenStr && !answer; i++) {
       if (str[i] == '?' || str[i] == '*') answer = true;
     }
     return answer;


### PR DESCRIPTION
Cast ECL string parameter lengths to int from unsigned to use in a for loop with int.

Signed-off-by: johnholt <john.d.holt@lexisnexisrisk.com>