### PR TITLE
TS-17 Add SuperKey alias support

### DIFF
--- a/TextSearch/Common/FileName_Info.ecl
+++ b/TextSearch/Common/FileName_Info.ecl
@@ -1,8 +1,13 @@
+//FileName Info structured used for file name generation.
+//This version includes pre-Slice management hack to support tracking update
+//versions with incremental updates.
 EXPORT FileName_Info := INTERFACE
   EXPORT STRING Prefix;
   EXPORT STRING Instance;    // the version for an individual instance or the Alias
   EXPORT STRING AliasInstance := 'CURRENT';
-  EXPORT UNSIGNED2 Naming := 1;
-  EXPORT UNSIGNED2 DataVersion := 0;
+  EXPORT SET OF STRING AliasInstances := [AliasInstance, 'LAST', 'PAST', 'DELETED'];
+  EXPORT UNSIGNED2 Naming := 1;       // version of naming system
+  EXPORT UNSIGNED2 DataVersion := 0;  // placeholder for data version to build
   EXPORT UNSIGNED1 Levels := 5;
+  EXPORT STRING UseInstance(UNSIGNED indx) := IF(indx=0, Instance, AliasInstances[indx]);
 END;

--- a/TextSearch/Common/FileNames.ecl
+++ b/TextSearch/Common/FileNames.ecl
@@ -9,11 +9,11 @@ IMPORT TextSearch.Common;
 // Instance is FileName.Instance; and Suffix is the data type as below.
 FileName_Info := Common.FileName_Info;
 
-EXPORT FileNames(FileName_Info info) := MODULE
+EXPORT FileNames(FileName_Info info, UNSIGNED Alias=0) := MODULE
   SHARED DocSearchPrefix := '::DocSearch::Level-';
   SHARED Name(STRING suffix, UNSIGNED lvl) := info.Prefix + DocSearchPrefix
                                             + INTFORMAT(lvl, 2, 1) + '::'
-                                            + info.Instance + '::' + suffix;
+                                            + info.UseInstance(Alias) + '::' + suffix;
 
   EXPORT DocumentIndex(UNSIGNED lvl=0) := Name('DocIndx', lvl);
   EXPORT TriGramDictionary(UNSIGNED lvl=0) := Name('TriDctIndx', lvl);
@@ -28,4 +28,26 @@ EXPORT FileNames(FileName_Info info) := MODULE
   EXPORT TagDictionary(UNSIGNED lvl=0) := Name('TagIndx', lvl);
   EXPORT IdentIndx(UNSIGNED1 lvl=0) := Name('IdentIndx', lvl);
   EXPORT DeleteIndex(UNSIGNED1 lvl=0) := NAME('DelIndx', lvl);
+  EXPORT NameEnum := Common.Types.FileEnum;
+  EXPORT NameByEnum(NameEnum ne, UNSIGNED1 lvl=0)
+      := CASE(ne,
+              NameEnum.DocumentIndex                => DocumentIndex(lvl),
+              NameEnum.TriGramDictionary            => TriGramDictionary(lvl),
+              NameEnum.TermDictionary               => TermDictionary(lvl),
+              NameEnum.TriGramIndex                 => TriGramIndex(lvl),
+              NameEnum.TermIndex                    => TermIndex(lvl),
+              NameEnum.PhraseIndex                  => PhraseIndex(lvl),
+              NameEnum.ElementIndex                 => ElementIndex(lvl),
+              NameEnum.AttributeIndex               => AttributeIndex(lvl),
+              NameEnum.RangeIndex                   => RangeIndex(lvl),
+              NameEnum.NameSpaceDict                => NameSpaceDict(lvl),
+              NameEnum.TagDictionary                => TagDictionary(lvl),
+              NameEnum.IdentIndx                    => IdentIndx(lvl),
+              NameEnum.DeleteIndex                  => DeleteIndex(lvl),
+              Name('BadEnum', lvl));
+  // the currently building keys.  Add triGramDictionary and TriGramIndex when ready
+  EXPORT NameSet := [NameEnum.DocumentIndex, NameEnum.TermDictionary, NameEnum.TermIndex,
+                     NameEnum.PhraseIndex, NameEnum.ElementIndex, NameEnum.AttributeIndex,
+                     NameEnum.RangeIndex, NameEnum.TagDictionary, NameEnum.IdentIndx,
+                     NameEnum.DeleteIndex];
 END;

--- a/TextSearch/Common/Types.ecl
+++ b/TextSearch/Common/Types.ecl
@@ -87,4 +87,8 @@ EXPORT Types := MODULE
   EXPORT DocIdentifier    := UNICODE;
   EXPORT SequenceKey      := STRING50;
   EXPORT SlugLine         := UNICODE;
+  EXPORT FileEnum := ENUM(UNSIGNED1, Unknown=0, DocumentIndex, TriGramDictionary,
+                          TermDictionary, TriGramIndex, TermIndex, PhraseIndex,
+                          ELementIndex, AttributeIndex, RangeIndex, NameSpaceDict,
+                          TagDictionary, IdentIndx, DeleteIndex);
 END;

--- a/TextSearch/Inverted/Basic_Key_List.ecl
+++ b/TextSearch/Inverted/Basic_Key_List.ecl
@@ -1,0 +1,21 @@
+IMPORT TextSearch.Inverted.Layouts;
+IMPORT TextSearch.Common;
+
+FileName_Info := Common.FileName_Info;
+FileName_Info_Instance := Common.FileName_Info_Instance;
+FileNames := Common.FileNames;
+Types := Common.Types;
+
+EXPORT DATASET(Layouts.Managed_File_Names) Basic_Key_List(FileName_Info info) := FUNCTION
+  Layouts.Managed_File_Names makeEntry(Types.FileEnum name) := TRANSFORM
+    SELF.logical_name := FileNames(info, 0).NameByEnum(name);
+    SELF.current_name := FileNames(info, 1).NameByEnum(name);
+    SELF.previous_name := FileNames(info, 2).NameByEnum(name);
+    SELF.past_previous_name := FileNames(info, 3).NameByEnum(name);
+    SELF.deleted_name := FileNames(info, 4).NameByEnum(name);
+    SELF.delete_deleted := TRUE;
+    SELF.task := Layouts.Management_Task.Replace;
+  END;
+  ds := DATASET(COUNT(FileNames(info).NameSet), makeEntry(FileNames(info).NameSet[COUNTER]));
+  RETURN ds;
+END;

--- a/TextSearch/Inverted/Build_Slice_Action.ecl
+++ b/TextSearch/Inverted/Build_Slice_Action.ecl
@@ -1,10 +1,14 @@
 ﻿// The action for building a slice, given the name of the Ingest file, and the
 //prefix and instance for the file names.
+// Optional parameter is a dataset used to list other files that we want managed.
 IMPORT TextSearch.Common;
 IMPORT TextSearch.Inverted;
 Ingest := Inverted.Layouts.DocumentIngest;
+Managed_File_Names := Inverted.Layouts.Managed_File_Names;
+empty := DATASET([], Managed_File_Names);
 
-EXPORT Build_Slice_Action(STRING ingestName, STRING prfx, STRING inst) := FUNCTION
+EXPORT Build_Slice_Action(STRING ingestName, STRING prfx, STRING inst,
+                          DATASET(Managed_File_Names) mfn=empty) := FUNCTION
   inDocs := DATASET(ingestName, Ingest, THOR);
   info := Common.FileName_Info_Instance(prfx, inst);
   kwm  := Common.Default_Keywording;
@@ -18,7 +22,7 @@ EXPORT Build_Slice_Action(STRING ingestName, STRING prfx, STRING inst) := FUNCTI
   TrmDict  := base.TermDict;
   TagDict  := base.TagDict;
   Replaced := base.ReplacedDocs;
-  ac := PARALLEL(
+  bc := PARALLEL(
     BUILD(Common.Keys(info).TermIndex(TrmPosts))
    ,BUILD(Common.Keys(info).ElementIndex(tagposts))
    ,BUILD(Common.Keys(info).PhraseIndex(PhrsPosts))
@@ -30,5 +34,13 @@ EXPORT Build_Slice_Action(STRING ingestName, STRING prfx, STRING inst) := FUNCTI
    ,BUILD(Common.Keys(info).IdentIndex(docIndx))
    ,BUILD(Common.Keys(info).DeleteIndex(Replaced))
   );
+  Task_Enum := Inverted.Layouts.Management_Task;
+  good_mfn := ASSERT(mfn, (task=Task_Enum.NoOp)
+                        OR (task=Task_Enum.Replace AND logical_name<>''
+                            AND current_name<>'' AND previous_name<>''
+                            AND past_previous_name<>'' AND deleted_name<>'' ),
+                      'Missing required file names for action', FAIL);
+  key_list := Inverted.Basic_Key_List(info) + good_mfn;
+  ac := SEQUENTIAL(bc, Inverted.Manage_Superkeys(info, key_list));
   RETURN ac;
 END;

--- a/TextSearch/Inverted/Layouts.ecl
+++ b/TextSearch/Inverted/Layouts.ecl
@@ -35,4 +35,15 @@ EXPORT Layouts := MODULE
     Types.PathString          pathString;
     Types.TermString          parentName;
   END;
+  // Record for the machinery to manage file names with super keys (super files)
+  EXPORT Management_Task := ENUM(UNSIGNED1, NoOp=0, Replace); // Future
+  EXPORT Managed_File_Names := RECORD
+    STRING logical_name;
+    STRING current_name;
+    STRING previous_name;
+    STRING past_previous_name;
+    STRING deleted_name;
+    BOOLEAN delete_deleted;
+    Management_Task task;
+  END;
 END;

--- a/TextSearch/Inverted/Manage_Superkeys.ecl
+++ b/TextSearch/Inverted/Manage_Superkeys.ecl
@@ -1,0 +1,39 @@
+// Version for pre-Slice keys.
+// Assumes that user replaces the collection.
+//
+IMPORT TextSearch.Common;
+IMPORT TextSearch.Inverted;
+IMPORT TextSeaRch.Inverted.Layouts;
+IMPORT STD.File AS FS;
+
+Managed_File_Names := Layouts.Managed_File_Names;
+Management_Task := Layouts.Management_Task;
+FileName_Info := Common.FileName_Info;
+
+
+EXPORT Manage_Superkeys(FileName_Info info, DATASET(Managed_File_Names) mfn) := FUNCTION
+  ac := SEQUENTIAL(
+      // Make sure the aliases exist, create as necessary
+      NOTHOR(APPLY(mfn,
+                  IF(NOT FS.SuperFileExists(current_name), FS.CreateSuperFile(current_name))
+                 ,IF(NOT FS.SuperFileExists(previous_name), FS.CreateSuperFile(previous_name))
+                 ,IF(NOT FS.SuperFileExists(past_previous_name), FS.CreateSuperFile(past_previous_name))
+                 ,IF(NOT FS.SuperFileExists(deleted_name), FS.CreateSuperFile(deleted_name))
+             ))
+     ,OUTPUT(mfn, NAMED('Files_List'))
+     ,FS.StartSuperFileTransaction()
+     ,NOTHOR(APPLY(mfn,
+                  FS.SwapSuperFile(deleted_name, past_previous_name)
+                 ,FS.SwapSuperFile(past_previous_name, previous_name)
+                 ,FS.SwapSuperFile(previous_name, current_name)
+                 ,FS.ClearSuperFile(current_name)
+                 ,FS.AddSuperFile(current_name, logical_name)
+            ))
+     ,FS.FinishSuperFileTransaction()
+     ,NOTHOR(APPLY(mfn,
+                  FS.RemoveOwnedSubFiles(deleted_name, delete_deleted)
+                 ,FS.ClearSuperFile(deleted_name)
+             ))
+  );
+  RETURN ac;
+END;


### PR DESCRIPTION
FileName_Info added a list of alias names for the super keys.

Filename modified to use alias names, a list of keys being built, and names by enumeration value.

Types added file name enumeration values.

Build Slice Action supports list of external co-managed files.

Layouts defined co-managed file information.

Signed-off-by: johnholt <john.d.holt@lexisnexisrisk.com>